### PR TITLE
handlers: Sort the LEDs before returning them to the client

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -20,7 +20,7 @@ pub struct Config {
     pub name: String,
     pub vendor_id: u16,
     pub product_id: u16,
-    pub leds: Vec<Option<(u8, Position)>>,
+    pub leds: Vec<(u8, Position)>,
     pub effects: Vec<Effect>,
     pub speed: Range,
     pub brightness: Range,
@@ -52,7 +52,7 @@ impl Config {
         })
     }
 
-    fn parse_leds(keymap: &[Vec<KeymapEntry>]) -> Vec<Option<(u8, Position)>> {
+    fn parse_leds(keymap: &[Vec<KeymapEntry>]) -> Vec<(u8, Position)> {
         keymap
             .iter()
             .flatten()
@@ -63,7 +63,7 @@ impl Config {
                     None
                 }
             })
-            .map(extract_led)
+            .filter_map(extract_led)
             .sorted()
             .collect()
     }
@@ -156,7 +156,7 @@ impl Config {
     }
 
     pub fn count_leds(&self) -> u32 {
-        let index = self.leds.iter().max().unwrap_or(&None);
+        let index = self.leds.iter().max();
         if let Some(index) = index {
             return index.0 as u32 + 1;
         } else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use evalexpr::{
     ContextWithMutableVariables, HashMapContext, Node, Value as EvalValue, build_operator_tree,
 };
+use itertools::Itertools;
 use serde::Deserialize;
 use serde_json::Value;
 
@@ -63,6 +64,7 @@ impl Config {
                 }
             })
             .map(extract_led)
+            .sorted()
             .collect()
     }
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,5 +1,6 @@
 use anyhow::{Result, anyhow};
 use colored::Colorize;
+use itertools::Itertools;
 use log::debug;
 use palette::{encoding::Srgb, rgb::Rgb};
 use std::path::PathBuf;
@@ -143,7 +144,7 @@ pub async fn handle(
 
             buffer.extend_from_slice(&(leds_count as u16).to_le_bytes());
             let keymap = keyboard.keymap();
-            for item in config.leds.iter() {
+            for item in config.leds.iter().sorted() {
                 if let &Some((led, (row, col))) = item {
                     let scancode = keymap[row as usize * config.matrix.0 as usize + col as usize];
                     buffer.extend_from_str(&format!("Key: {}", openrgb_keycode(scancode)));

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -136,19 +136,17 @@ pub async fn handle(
             buffer.extend_from_slice(&config.matrix.0.to_le_bytes());
 
             let mut led_matrix = vec![0xFFFFFFFF; (config.matrix.0 * config.matrix.1) as usize];
-            for (led, (row, col)) in config.leds.iter().filter_map(|led| *led) {
+            for &(led, (row, col)) in config.leds.iter() {
                 led_matrix[row as usize * config.matrix.0 as usize + col as usize] = led as u32;
             }
             buffer.extend_from_u32s(&led_matrix);
 
             buffer.extend_from_slice(&(leds_count as u16).to_le_bytes());
             let keymap = keyboard.keymap();
-            for item in config.leds.iter() {
-                if let &Some((led, (row, col))) = item {
-                    let scancode = keymap[row as usize * config.matrix.0 as usize + col as usize];
-                    buffer.extend_from_str(&format!("Key: {}", openrgb_keycode(scancode)));
-                    buffer.extend_from_slice(&(led as u32).to_le_bytes());
-                }
+            for &(led, (row, col)) in config.leds.iter() {
+                let scancode = keymap[row as usize * config.matrix.0 as usize + col as usize];
+                buffer.extend_from_str(&format!("Key: {}", openrgb_keycode(scancode)));
+                buffer.extend_from_slice(&(led as u32).to_le_bytes());
             }
 
             buffer.extend_from_slice(&(leds_count as u16).to_le_bytes());

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,6 +1,5 @@
 use anyhow::{Result, anyhow};
 use colored::Colorize;
-use itertools::Itertools;
 use log::debug;
 use palette::{encoding::Srgb, rgb::Rgb};
 use std::path::PathBuf;
@@ -144,7 +143,7 @@ pub async fn handle(
 
             buffer.extend_from_slice(&(leds_count as u16).to_le_bytes());
             let keymap = keyboard.keymap();
-            for item in config.leds.iter().sorted() {
+            for item in config.leds.iter() {
                 if let &Some((led, (row, col))) = item {
                     let scancode = keymap[row as usize * config.matrix.0 as usize + col as usize];
                     buffer.extend_from_str(&format!("Key: {}", openrgb_keycode(scancode)));


### PR DESCRIPTION
This changes the order in which ColorHoster presents the LEDs to connecting clients. Before this change, the LEDs were sent in the same order as they were defined in, in the VIA config file. On some keyboards this order does not match the key order, for example on the RK61 every other row is wired backwards:

```json
{
  "keymap": [
    [
      {
        "c": "#FFFFFF"
      },
      "0,0\nl13\n\n\n\n\n\n\n\nESC",
      "0,1\nl12",
      "0,2\nl11",
      "0,3\nl10",
      "0,4\nl9",
      "0,5\nl8",
      "0,6\nl7",
      "0,7\nl6",
      "0,8\nl5",
      "0,9\nl4",
      "0,10\nl3",
      "0,11\nl2",
      "0,12\nl1",
      {
        "w": 2
      },
      "0,13\nl0"
    ],
    [
      {
        "w": 1.5
      },
      "1,0\nl14",
      "1,1\nl15",
      "1,2\nl16",
      "1,3\nl17",
      "1,4\nl18",
      "1,5\nl19",
      "1,6\nl20",
      "1,7\nl21",
      "1,8\nl22",
      "1,9\nl23",
      "1,10\nl24",
      "1,11\nl25",
      "1,12\nl26",
      {
        "w": 1.5
      },
      "1,13\nl27"
    ],
    [
      {
        "w": 1.75
      },
      "2,0\nl40",
      "2,1\nl39",
      "2,2\nl38",
      "2,3\nl37",
      "2,4\nl36",
      "2,5\nl35",
      "2,6\nl34",
      "2,7\nl33",
      "2,8\nl32",
      "2,9\nl31",
      "2,10\nl30",
      "2,11\nl29",
      {
        "w": 2.25
      },
      "2,12\nl28"
    ],
    [
      {
        "w": 2.25
      },
      "3,0\nl41",
      "3,1\nl42",
      "3,2\nl43",
      "3,3\nl44",
      "3,4\nl45",
      "3,5\nl46",
      "3,6\nl47",
      "3,7\nl48",
      "3,8\nl49",
      "3,9\nl50",
      "3,10\nl51",
      {
        "w": 2.75
      },
      "3,11\nl52"
    ],
    [
      {
        "w": 1.25
      },
      "4,0\nl60",
      {
        "w": 1.25
      },
      "4,1\nl59",
      {
        "w": 1.25
      },
      "4,2\nl58",
      {
        "w": 6.25
      },
      "4,5\nl57",
      {
        "w": 1.25
      },
      "4,8\nl56",
      {
        "w": 1.25
      },
      "4,9\nl55",
      {
        "w": 1.25
      },
      "4,10\nl54",
      {
        "w": 1.25
      },
      "4,12\nl53"
    ]
  ]
}
```

That caused OpenRGB to see the the reversed rows in reversed order:
<img width="1033" height="773" alt="image" src="https://github.com/user-attachments/assets/19e1da4e-67cc-4e8b-8796-30e4edaf689e" />

After this change:
<img width="1033" height="773" alt="image" src="https://github.com/user-attachments/assets/4be80eeb-c7f7-4712-9f81-28e0f71e4a83" />