### PR TITLE
Add vendor support to the config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,32 +2,7 @@
 
 - Added support for the vendor flag on OpenRGB clients.
 
-  To make use of this, add the following to the beginning of your JSON config (examples):
-
-  SteelSeries.apex5_ansi.json -> SteelSeries
-  
-  Cooler-Master.ck352_ansi.json -> Cooler Master
-  
-  Cooler.Master.ck352_ansi.json -> Cooler
-  
-  Cooler+Master.ck352_ansi.json -> Cooler+Master
-  
-  Cooler+-Master.ck352_ansi.json -> Cooler-Master
-  
-  Cooler+.Master.ck352_ansi.json -> Cooler.Master
-  
-  
-  ### Filename legend:
-
-  `-` = space
-  
-  `.` = vendor|name separator
-  
-  `+-` = literal - (escape sequence for actual dash if needed)
-  
-  `+.` = literal . (escape sequence for actual dot if needed)
-  
-  
+  The vendor name is automatically read from the keyboard's QMK firmware. The `vendorId` and `productId` in your ColorHoster JSON are used to identify the correct device. The manufacturer name compiled into the firmware is then reported to OpenRGB clients.
 
 ## 0.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,34 @@
+## 0.7.1
+
+- Added support for the vendor flag on OpenRGB clients.
+
+  To make use of this, add the following to the beginning of your JSON config (examples):
+
+  SteelSeries.apex5_ansi.json -> SteelSeries
+  
+  Cooler-Master.ck352_ansi.json -> Cooler Master
+  
+  Cooler.Master.ck352_ansi.json -> Cooler
+  
+  Cooler+Master.ck352_ansi.json -> Cooler+Master
+  
+  Cooler+-Master.ck352_ansi.json -> Cooler-Master
+  
+  Cooler+.Master.ck352_ansi.json -> Cooler.Master
+  
+  
+  ### Filename legend:
+
+  `-` = space
+  
+  `.` = vendor|name separator
+  
+  `+-` = literal - (escape sequence for actual dash if needed)
+  
+  `+.` = literal . (escape sequence for actual dot if needed)
+  
+  
+
 ## 0.7.0
 
 - (potentially breaking) Direct mode is now always reported to clients at index 0 (this does not affect your JSON configs)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Added support for the vendor flag on OpenRGB clients.
 
-  The vendor name is automatically read from the keyboard's QMK firmware. The `vendorId` and `productId` in your ColorHoster JSON are used to identify the correct device. The manufacturer name compiled into the firmware is then reported to OpenRGB clients.
+  The vendor name is read from the manufacturer string from what the OS got off the keyboard's USB firmware when it was plugged in, using the manufacturer field added to async-hid's DeviceInfo in version 0.5.1. The manufacturer name has been compiled into the QMK firmware and is then basically reported to OpenRGB clients.
 
 ## 0.7.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "ColorHoster"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-hid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,9 +104,9 @@ dependencies = [
 
 [[package]]
 name = "async-hid"
-version = "0.4.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aab637ea12169f6c473eaed9fe56843490146e3d431dbe408ca86d92edf79c2e"
+checksum = "69e70a2c939b6c214ac83665d66aa8de5f5ecda851cd589f2aa71904822963ab"
 dependencies = [
  "async-io",
  "atomic-waker",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ColorHoster"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 anyhow = "1.0.97"
-async-hid = "0.4.2"
+async-hid = "0.5.1"
 ceviche = "0.7.0"
 chrono = "0.4.40"
 clap = { version = "4.5.32", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ itertools = "0.14.0"
 log = "0.4.26"
 num_enum = "0.7.3"
 palette = "0.7.6"
-rusb = "0.9.4"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 tokio = { version = "1.44.2", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ itertools = "0.14.0"
 log = "0.4.26"
 num_enum = "0.7.3"
 palette = "0.7.6"
+rusb = "0.9.4"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 tokio = { version = "1.44.2", features = ["full"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,7 @@ type Effect = (String, i32, u32);
 #[derive(Debug, Clone)]
 pub struct Config {
     pub name: String,
+    pub vendor: String,
     pub vendor_id: u16,
     pub product_id: u16,
     pub leds: Vec<(u8, Position)>,
@@ -31,6 +32,7 @@ impl Config {
     pub fn from_str(json: &str) -> Result<Self> {
         let KeyboardJson {
             name,
+            vendor,
             vendor_id,
             product_id,
             matrix,
@@ -42,6 +44,7 @@ impl Config {
 
         Ok(Self {
             name,
+            vendor: vendor.unwrap_or_else(|| "Unknown".to_string()),
             vendor_id: parse_hex(&vendor_id),
             product_id: parse_hex(&product_id),
             matrix: (matrix.cols, matrix.rows),
@@ -253,6 +256,8 @@ fn extract_led(key: &String) -> Option<(u8, Position)> {
 #[derive(Debug, Deserialize)]
 struct KeyboardJson {
     name: String,
+    #[serde(default)]
+    vendor: Option<String>,
     #[serde(rename = "vendorId")]
     vendor_id: String,
     #[serde(rename = "productId")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,7 +32,6 @@ impl Config {
     pub fn from_str(json: &str) -> Result<Self> {
         let KeyboardJson {
             name,
-            vendor,
             vendor_id,
             product_id,
             matrix,
@@ -44,7 +43,7 @@ impl Config {
 
         Ok(Self {
             name,
-            vendor: vendor.filter(|v| !v.trim().is_empty()).unwrap_or_else(|| "Unknown".to_string()),
+            vendor: "Unknown".to_string(),
             vendor_id: parse_hex(&vendor_id),
             product_id: parse_hex(&product_id),
             matrix: (matrix.cols, matrix.rows),
@@ -256,8 +255,6 @@ fn extract_led(key: &String) -> Option<(u8, Position)> {
 #[derive(Debug, Deserialize)]
 struct KeyboardJson {
     name: String,
-    #[serde(default)]
-    vendor: Option<String>,
     #[serde(rename = "vendorId")]
     vendor_id: String,
     #[serde(rename = "productId")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,7 +44,7 @@ impl Config {
 
         Ok(Self {
             name,
-            vendor: vendor.unwrap_or_else(|| "Unknown".to_string()),
+            vendor: vendor.filter(|v| !v.trim().is_empty()).unwrap_or_else(|| "Unknown".to_string()),
             vendor_id: parse_hex(&vendor_id),
             product_id: parse_hex(&product_id),
             matrix: (matrix.cols, matrix.rows),

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -90,7 +90,7 @@ pub async fn handle(
             if ctx.protocol_version >= 1 {
                 buffer.extend_from_str(&config.vendor);
             }
-            buffer.extend_from_str(&format!("{} via ColorHoster", &config.name));
+            buffer.extend_from_str(&format!("{} {} via ColorHoster", &config.vendor, &config.name));
             buffer.extend_from_str(env!("CARGO_PKG_VERSION"));
             buffer.extend_from_str(&id);
             buffer.extend_from_str(&format!("HID: {}", id));

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -88,7 +88,7 @@ pub async fn handle(
             buffer.extend_from_slice(&DEVICE_TYPE_KEYBOARD.to_le_bytes());
             buffer.extend_from_str(&config.name);
             if ctx.protocol_version >= 1 {
-                buffer.extend_from_str("Unknown");
+                buffer.extend_from_str(&config.vendor);
             }
             buffer.extend_from_str(&format!("{} via ColorHoster", &config.name));
             buffer.extend_from_str(env!("CARGO_PKG_VERSION"));

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -90,7 +90,10 @@ pub async fn handle(
             if ctx.protocol_version >= 1 {
                 buffer.extend_from_str(&config.vendor);
             }
-            buffer.extend_from_str(&format!("{} {} via ColorHoster", &config.vendor, &config.name));
+            buffer.extend_from_str(&format!(
+                "{} {} via ColorHoster",
+                &config.vendor, &config.name
+            ));
             buffer.extend_from_str(env!("CARGO_PKG_VERSION"));
             buffer.extend_from_str(&id);
             buffer.extend_from_str(&format!("HID: {}", id));

--- a/src/keyboards.rs
+++ b/src/keyboards.rs
@@ -80,7 +80,7 @@ impl Keyboards {
                 if let Some(manufacturer) = read_manufacturer(config.vendor_id, config.product_id) {
                     config.vendor = manufacturer;
                 }
-                debug!("Keyboard {} {} connected!", config.vendor.bold().cyan(), config.name.bold());
+                debug!("Keyboard {} {} connected!", config.vendor.bold().cyan(), config.name.bold().blue());
                 match Keyboard::from_config(config, device).await {
                     Err(error) => warn!("Failed to initialize keyboard: {error}"),
                     Ok(keyboard) => {
@@ -121,7 +121,7 @@ impl Keyboards {
                                 if let Some(manufacturer) = read_manufacturer(config.vendor_id, config.product_id) {
                                     config.vendor = manufacturer;
                                 }
-                                debug!("Keyboard {} {} connected!", config.vendor.bold().cyan(), config.name.bold());
+                                debug!("Keyboard {} {} connected!", config.vendor.bold().cyan(), config.name.bold().blue());
                                 match Keyboard::from_config(config, device).await {
                                     Err(error) => warn!("Failed to initialize keyboard: {error}"),
                                     Ok(keyboard) => {
@@ -135,7 +135,7 @@ impl Keyboards {
                         DeviceEvent::Disconnected(id) => {
                             if let Some(device) = keyboards.lock().await.shift_remove(&id) {
                                 let config = device.into_config().await;
-                                debug!("Keyboard {} {} disconnected!", config.vendor.bold().cyan(), config.name.bold());
+                                debug!("Keyboard {} {} disconnected!", config.vendor.bold().cyan(), config.name.bold().blue());
 
                                 configs
                                     .lock()

--- a/src/keyboards.rs
+++ b/src/keyboards.rs
@@ -4,11 +4,9 @@ use colored::Colorize;
 use futures::StreamExt;
 use indexmap::IndexMap;
 use log::{debug, warn};
-use rusb::{Context as UsbContext, UsbContext as _};
 use std::{
     collections::HashMap,
-    sync::{Arc, Mutex},
-    time::Duration
+    sync::{Arc, Mutex}
 };
 use tokio::sync::{
     Mutex as AsyncMutex, MutexGuard,
@@ -20,46 +18,6 @@ use crate::{
     consts::{QMK_USAGE_ID, QMK_USAGE_PAGE},
     keyboard::Keyboard,
 };
-
-fn read_manufacturer(vendor_id: u16, product_id: u16) -> Option<String> {
-    let context = UsbContext::new().ok()?;
-    let devices = context.devices().ok()?;
-
-    for device in devices.iter() {
-        let desc = match device.device_descriptor() {
-            Ok(d) => d,
-            Err(_) => continue,
-        };
-
-        if desc.vendor_id() != vendor_id || desc.product_id() != product_id {
-            continue;
-        }
-
-        let handle = match device.open() {
-            Ok(h) => h,
-            Err(_) => continue,
-        };
-
-        let timeout = Duration::from_millis(1000);
-        let languages = match handle.read_languages(timeout) {
-            Ok (l) => l,
-            Err(_) => continue,
-        };
-
-        let language = match languages.first() {
-            Some(&l) => l,
-            None => continue,
-        };
-
-        if let Ok(manufacturer) = handle.read_manufacturer_string(language, &desc, timeout) {
-            if !manufacturer.is_empty() {
-                return Some(manufacturer);
-            }
-        }
-    }
-
-    None
-}
 
 #[derive(Clone)]
 pub struct Keyboards {
@@ -77,7 +35,7 @@ impl Keyboards {
 
         while let Some(device) = stream.next().await {
             if is_compatible(&device) && let Some(mut config) = configs.remove(&(device.vendor_id, device.product_id)) {
-                if let Some(manufacturer) = read_manufacturer(config.vendor_id, config.product_id) {
+                if let Some(manufacturer) = device.manufacturer.clone() {
                     config.vendor = manufacturer;
                 }
                 debug!("Keyboard {} {} connected!", config.vendor.bold().cyan(), config.name.bold().blue());
@@ -118,7 +76,7 @@ impl Keyboards {
                             });
 
                             if let (Some(mut config), Some(device)) = (config, device) {
-                                if let Some(manufacturer) = read_manufacturer(config.vendor_id, config.product_id) {
+                                if let Some(manufacturer) = device.manufacturer.clone() {
                                     config.vendor = manufacturer;
                                 }
                                 debug!("Keyboard {} {} connected!", config.vendor.bold().cyan(), config.name.bold().blue());

--- a/src/keyboards.rs
+++ b/src/keyboards.rs
@@ -80,7 +80,7 @@ impl Keyboards {
                 if let Some(manufacturer) = read_manufacturer(config.vendor_id, config.product_id) {
                     config.vendor = manufacturer;
                 }
-                debug!("Keyboard {} {} connected!", config.vendor.bold(), config.name.bold());
+                debug!("Keyboard {} {} connected!", config.vendor.bold().cyan(), config.name.bold());
                 match Keyboard::from_config(config, device).await {
                     Err(error) => warn!("Failed to initialize keyboard: {error}"),
                     Ok(keyboard) => {
@@ -121,7 +121,7 @@ impl Keyboards {
                                 if let Some(manufacturer) = read_manufacturer(config.vendor_id, config.product_id) {
                                     config.vendor = manufacturer;
                                 }
-                                debug!("Keyboard {} {} connected!", config.vendor.bold(), config.name.bold());
+                                debug!("Keyboard {} {} connected!", config.vendor.bold().cyan(), config.name.bold());
                                 match Keyboard::from_config(config, device).await {
                                     Err(error) => warn!("Failed to initialize keyboard: {error}"),
                                     Ok(keyboard) => {
@@ -135,7 +135,7 @@ impl Keyboards {
                         DeviceEvent::Disconnected(id) => {
                             if let Some(device) = keyboards.lock().await.shift_remove(&id) {
                                 let config = device.into_config().await;
-                                debug!("Keyboard {} {} disconnected!", config.vendor.bold(), config.name.bold());
+                                debug!("Keyboard {} {} disconnected!", config.vendor.bold().cyan(), config.name.bold());
 
                                 configs
                                     .lock()

--- a/src/keyboards.rs
+++ b/src/keyboards.rs
@@ -37,7 +37,7 @@ impl Keyboards {
             if is_compatible(&device)
                 && let Some(config) = configs.remove(&(device.vendor_id, device.product_id))
             {
-                debug!("Keyboard {} connected!", config.name.bold());
+                debug!("Keyboard {} {} connected!", config.vendor.bold(), config.name.bold());
                 match Keyboard::from_config(config, device).await {
                     Err(error) => warn!("Failed to initialize keyboard: {error}"),
                     Ok(keyboard) => {
@@ -75,7 +75,7 @@ impl Keyboards {
                             });
 
                             if let (Some(config), Some(device)) = (config, device) {
-                                debug!("Keyboard {} connected!", config.name.bold());
+                                debug!("Keyboard {} {} connected!", config.vendor.bold(), config.name.bold());
                                 match Keyboard::from_config(config, device).await {
                                     Err(error) => warn!("Failed to initialize keyboard: {error}"),
                                     Ok(keyboard) => {
@@ -89,7 +89,7 @@ impl Keyboards {
                         DeviceEvent::Disconnected(id) => {
                             if let Some(device) = keyboards.lock().await.shift_remove(&id) {
                                 let config = device.into_config().await;
-                                debug!("Keyboard {} disconnected!", config.name.bold());
+                                debug!("Keyboard {} {} disconnected!", config.vendor.bold(), config.name.bold());
 
                                 configs
                                     .lock()

--- a/src/keyboards.rs
+++ b/src/keyboards.rs
@@ -4,9 +4,11 @@ use colored::Colorize;
 use futures::StreamExt;
 use indexmap::IndexMap;
 use log::{debug, warn};
+use rusb::{Context as UsbContext, UsbContext as _};
 use std::{
     collections::HashMap,
     sync::{Arc, Mutex},
+    time::Duration
 };
 use tokio::sync::{
     Mutex as AsyncMutex, MutexGuard,
@@ -18,6 +20,46 @@ use crate::{
     consts::{QMK_USAGE_ID, QMK_USAGE_PAGE},
     keyboard::Keyboard,
 };
+
+fn read_manufacturer(vendor_id: u16, product_id: u16) -> Option<String> {
+    let context = UsbContext::new().ok()?;
+    let devices = context.devices().ok()?;
+
+    for device in devices.iter() {
+        let desc = match device.device_descriptor() {
+            Ok(d) => d,
+            Err(_) => continue,
+        };
+
+        if desc.vendor_id() != vendor_id || desc.product_id() != product_id {
+            continue;
+        }
+
+        let handle = match device.open() {
+            Ok(h) => h,
+            Err(_) => continue,
+        };
+
+        let timeout = Duration::from_millis(1000);
+        let languages = match handle.read_languages(timeout) {
+            Ok (l) => l,
+            Err(_) => continue,
+        };
+
+        let language = match languages.first() {
+            Some(&l) => l,
+            None => continue,
+        };
+
+        if let Ok(manufacturer) = handle.read_manufacturer_string(language, &desc, timeout) {
+            if !manufacturer.is_empty() {
+                return Some(manufacturer);
+            }
+        }
+    }
+
+    None
+}
 
 #[derive(Clone)]
 pub struct Keyboards {
@@ -35,8 +77,11 @@ impl Keyboards {
 
         while let Some(device) = stream.next().await {
             if is_compatible(&device)
-                && let Some(config) = configs.remove(&(device.vendor_id, device.product_id))
+                && let Some(mut config) = configs.remove(&(device.vendor_id, device.product_id))
             {
+                if let Some(manufacturer) = read_manufacturer(config.vendor_id, config.product_id) {
+                    config.vendor = manufacturer;
+                }
                 debug!("Keyboard {} {} connected!", config.vendor.bold(), config.name.bold());
                 match Keyboard::from_config(config, device).await {
                     Err(error) => warn!("Failed to initialize keyboard: {error}"),
@@ -74,7 +119,10 @@ impl Keyboards {
                                 configs.lock().unwrap().remove(key)
                             });
 
-                            if let (Some(config), Some(device)) = (config, device) {
+                            if let (Some(mut config), Some(device)) = (config, device) {
+                                if let Some(manufacturer) = read_manufacturer(config.vendor_id, config.product_id) {
+                                    config.vendor = manufacturer;
+                                }
                                 debug!("Keyboard {} {} connected!", config.vendor.bold(), config.name.bold());
                                 match Keyboard::from_config(config, device).await {
                                     Err(error) => warn!("Failed to initialize keyboard: {error}"),

--- a/src/keyboards.rs
+++ b/src/keyboards.rs
@@ -76,9 +76,7 @@ impl Keyboards {
         let mut stream = backend.enumerate().await?;
 
         while let Some(device) = stream.next().await {
-            if is_compatible(&device)
-                && let Some(mut config) = configs.remove(&(device.vendor_id, device.product_id))
-            {
+            if is_compatible(&device) && let Some(mut config) = configs.remove(&(device.vendor_id, device.product_id)) {
                 if let Some(manufacturer) = read_manufacturer(config.vendor_id, config.product_id) {
                     config.vendor = manufacturer;
                 }

--- a/src/keyboards.rs
+++ b/src/keyboards.rs
@@ -6,7 +6,7 @@ use indexmap::IndexMap;
 use log::{debug, warn};
 use std::{
     collections::HashMap,
-    sync::{Arc, Mutex}
+    sync::{Arc, Mutex},
 };
 use tokio::sync::{
     Mutex as AsyncMutex, MutexGuard,
@@ -34,11 +34,17 @@ impl Keyboards {
         let mut stream = backend.enumerate().await?;
 
         while let Some(device) = stream.next().await {
-            if is_compatible(&device) && let Some(mut config) = configs.remove(&(device.vendor_id, device.product_id)) {
+            if is_compatible(&device)
+                && let Some(mut config) = configs.remove(&(device.vendor_id, device.product_id))
+            {
                 if let Some(manufacturer) = device.manufacturer.clone() {
                     config.vendor = manufacturer;
                 }
-                debug!("Keyboard {} {} connected!", config.vendor.bold().cyan(), config.name.bold().blue());
+                debug!(
+                    "Keyboard {} {} connected!",
+                    config.name.bold().blue(),
+                    format!("({})", config.vendor).bold().cyan()
+                );
                 match Keyboard::from_config(config, device).await {
                     Err(error) => warn!("Failed to initialize keyboard: {error}"),
                     Ok(keyboard) => {
@@ -79,7 +85,11 @@ impl Keyboards {
                                 if let Some(manufacturer) = device.manufacturer.clone() {
                                     config.vendor = manufacturer;
                                 }
-                                debug!("Keyboard {} {} connected!", config.vendor.bold().cyan(), config.name.bold().blue());
+                                debug!(
+                                    "Keyboard {} {} connected!",
+                                    config.name.bold().blue(),
+                                    format!("({})", config.vendor).bold().cyan()
+                                );
                                 match Keyboard::from_config(config, device).await {
                                     Err(error) => warn!("Failed to initialize keyboard: {error}"),
                                     Ok(keyboard) => {
@@ -93,7 +103,11 @@ impl Keyboards {
                         DeviceEvent::Disconnected(id) => {
                             if let Some(device) = keyboards.lock().await.shift_remove(&id) {
                                 let config = device.into_config().await;
-                                debug!("Keyboard {} {} disconnected!", config.vendor.bold().cyan(), config.name.bold().blue());
+                                debug!(
+                                    "Keyboard {} {} disconnected!",
+                                    config.name.bold().blue(),
+                                    format!("({})", config.vendor).bold().cyan()
+                                );
 
                                 configs
                                     .lock()

--- a/src/main.rs
+++ b/src/main.rs
@@ -193,64 +193,6 @@ async fn handle_connection(mut stream: TcpStream, ctx: &mut HandlerContext) -> R
     }
 }
 
-fn parse_vendor_filename(stem: &str) -> Option<String> {
-    let chars: Vec<char> = stem.chars().collect();
-    let mut split_pos = None;
-    let mut i = 0;
-
-    while i < chars.len() {
-        if chars[i] == '+' && i + 1 < chars.len() && chars[i + 1] == '.' {
-            i += 2;
-        } else if chars[i] == '.' {
-            split_pos = Some(i);
-            break;
-        } else {
-            i += 1;
-        }
-    }
-
-    if split_pos.is_none() {
-        split_pos = chars.iter().position(|&c| c == '.');
-    }
-
-    let split_pos = split_pos?;
-
-    let vendor_part: String = chars[..split_pos].iter().collect();
-
-    let vendor_part = if let Some((_, right)) = vendor_part.rsplit_once(' ') {
-        right.to_string()
-    } else {
-        vendor_part
-    };
-
-    if vendor_part.is_empty() {
-        return None;
-    }
-
-    let chars: Vec<char> = vendor_part.chars().collect();
-    let mut result = String::new();
-    let mut i = 0;
-
-    while i < chars.len() {
-        if chars[i] == '+' && i + 1 < chars.len() && chars[i + 1] == '-' {
-            result.push('-');
-            i += 2;
-        } else if chars[i] == '+' && i + 1 < chars.len() && chars[i + 1] == '.' {
-            result.push('.');
-            i += 2;
-        } else if chars[i] == '-' {
-            result.push(' ');
-            i += 1;
-        } else {
-            result.push(chars[i]);
-            i += 1;
-        }
-    }
-
-    let collapsed = result.split_whitespace().collect::<Vec<_>>().join(" ");
-    if collapsed.is_empty() { None } else { Some(collapsed) }
-}
-
 async fn load_keyboards(directory: Option<PathBuf>, json: Vec<PathBuf>) -> Result<Keyboards> {
     let configs = directory
         .unwrap_or(CLI::current_dir())
@@ -264,20 +206,9 @@ async fn load_keyboards(directory: Option<PathBuf>, json: Vec<PathBuf>) -> Resul
             }
         })
         .chain(json.into_iter())
-        .filter_map(|path| {
-            let stem = path.file_stem()?.to_str()?.to_string();
-            let content = fs::read_to_string(&path).ok()?;
-            Some((stem, content))
-        })
-        .unique_by(|(_, content)| content.clone())
-        .map(|(stem, content)| {
-            Config::from_str(&content).map(|mut config| {
-                if let Some(filename_vendor) = parse_vendor_filename(&stem) {
-                    config.vendor = filename_vendor;
-                }
-                ((config.vendor_id, config.product_id), config)
-            })
-        })
+        .filter_map(|x| fs::read_to_string(x).ok())
+        .unique()
+        .map(|x| Config::from_str(&x).map(|config| ((config.vendor_id, config.product_id), config)))
         .collect::<Result<HashMap<_, _>>>()?;
 
     if configs.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -209,6 +209,10 @@ fn parse_vendor_filename(stem: &str) -> Option<String> {
         }
     }
 
+    if split_pos.is_none() {
+        split_pos = chars.iter().position(|&c| c == '.');
+    }
+
     let split_pos = split_pos?;
 
     let vendor_part: String = chars[..split_pos].iter().collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -193,6 +193,54 @@ async fn handle_connection(mut stream: TcpStream, ctx: &mut HandlerContext) -> R
     }
 }
 
+fn parse_vendor_filename(stem: &str) -> Option<String> {
+    let chars: Vec<char> = stem.chars().collect();
+    let mut split_pos = None;
+    let mut i = 0;
+
+    while i < chars.len() {
+        if chars[i] == '+' && i + 1 < chars.len() && chars[i + 1] == '.' {
+            i += 2;
+        } else if chars[i] == '.' {
+            split_pos = Some(i);
+            break;
+        } else {
+            i += 1;
+        }
+    }
+
+    let split_pos = split_pos?;
+
+    let vendor_part: String = chars[..split_pos].iter().collect();
+
+    if vendor_part.is_empty() {
+        return None;
+    }
+
+    let chars: Vec<char> = vendor_part.chars().collect();
+    let mut result = String::new();
+    let mut i = 0;
+
+    while i < chars.len() {
+        if chars[i] == '+' && i + 1 < chars.len() && chars[i + 1] == '-' {
+            result.push('-');
+            i += 2;
+        } else if chars[i] == '+' && i + 1 < chars.len() && chars[i + 1] == '.' {
+            result.push('.');
+            i += 2;
+        } else if chars[i] == '-' {
+            result.push(' ');
+            i += 1;
+        } else {
+            result.push(chars[i]);
+            i += 1;
+        }
+    }
+
+    let collapsed = result.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.is_empty() { None } else { Some(collapsed) }
+}
+
 async fn load_keyboards(directory: Option<PathBuf>, json: Vec<PathBuf>) -> Result<Keyboards> {
     let configs = directory
         .unwrap_or(CLI::current_dir())
@@ -206,9 +254,20 @@ async fn load_keyboards(directory: Option<PathBuf>, json: Vec<PathBuf>) -> Resul
             }
         })
         .chain(json.into_iter())
-        .filter_map(|x| fs::read_to_string(x).ok())
-        .unique()
-        .map(|x| Config::from_str(&x).map(|config| ((config.vendor_id, config.product_id), config)))
+        .filter_map(|path| {
+            let stem = path.file_stem()?.to_str()?.to_string();
+            let content = fs::read_to_string(&path).ok()?;
+            Some((stem, content))
+        })
+        .unique_by(|(_, content)| content.clone())
+        .map(|(stem, content)| {
+            Config::from_str(&content).map(|mut config| {
+                if let Some(filename_vendor) = parse_vendor_filename(&stem) {
+                    config.vendor = filename_vendor;
+                }
+                ((config.vendor_id, config.product_id), config)
+            })
+        })
         .collect::<Result<HashMap<_, _>>>()?;
 
     if configs.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -213,6 +213,12 @@ fn parse_vendor_filename(stem: &str) -> Option<String> {
 
     let vendor_part: String = chars[..split_pos].iter().collect();
 
+    let vendor_part = if let Some((_, right)) = vendor_part.rsplit_once(' ') {
+        right.to_string()
+    } else {
+        vendor_part
+    };
+
     if vendor_part.is_empty() {
         return None;
     }


### PR DESCRIPTION
This pull request aims to add a new vendor property to the json configurations.
The reasoning behind this is simple:
- OpenRGB reports the vendor as Unknown
- Artemis does the same, which breaks workshop support (more to that later)

Proof:
<img width="867" height="465" alt="image" src="https://github.com/user-attachments/assets/1785c7ad-bebe-4555-baaf-fc460a09ac44" />
<img width="1402" height="832" alt="image" src="https://github.com/user-attachments/assets/fd49f75f-8fbf-4e9c-bad7-656a635a9e22" />

This PR:
<img width="867" height="465" alt="image" src="https://github.com/user-attachments/assets/7d007a88-7c4b-4429-a130-936585320aa3" />
<img width="1402" height="832" alt="image" src="https://github.com/user-attachments/assets/7aba99f4-f5bc-4926-afdf-3cc51c8a9049" />

Why is this needed, especially in Artemis?
OpenRGB:
Instead of forcing "Unknown", we should at least make use of that property, even if it's not being shown in the device list.

Artemis:
Artemis has a workshop, to make layouts, plugins, etc, and post them to the public.
It also has a `Auto-install layouts` function to detect the keyboard (based on the vendor and probably closest thing it can fuzzy search through the workshop as the name, the latter, I am not so sure).
If my keyboard has the vendor "Unknown", which, using ColorHoster, was hardcoded to be, it cannot find that layout anymore.
I can manually install the layout onto the keyboard, however, not being able to auto-install is still a dealbreaker, especially when cycling through PCs or operating systems.
Here's an example of said button:
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/6ede2c5d-9c23-4528-b86e-b59c8cee3429" />

I tried keeping compatibility with old .json files inside https://github.com/JAO1988/ColorHoster-JSON, by returning the name "Unknown", if the vendor entry is either missing (old .json files), exists but is empty or only has spaces/no-characters.
(@JAO1988 obligatory ping to make you aware of this pull request, if this actually ends up being merged; You may want to look into adding the vendor entry to all currently existing .json files)

I also found it quite important to include the vendor name in the logs of ColorHoster, as well as the description of the device (which btw. is not shown in the devices tab either, so adding the vendor too ain't wrong):
<img width="1115" height="628" alt="image" src="https://github.com/user-attachments/assets/c81dc3ed-652c-4d1d-a70f-bb18045523c1" />
<img width="867" height="465" alt="image" src="https://github.com/user-attachments/assets/777316e6-81f3-406b-bda8-1292bbb38d00" />

I hope this is all fine