### PR TITLE
Update to version 0.7.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ColorHoster"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 
 [dependencies]

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -19,6 +19,7 @@ pub enum Request {
     SetCustomMode = 1100,
     UpdateMode = 1101,
     SaveMode = 1102,
+    UpdateZoneMode = 1103,
 }
 
 pub const OPENRGB_PROTOCOL_VERSION: u32 = 0x3;


### PR DESCRIPTION
This is a bugfix for OpenRGB 1.0RC3. Added additional request ID 1103 for OpenRGB Client Compliance. 
Note this does not change the current ColorHoster API version.